### PR TITLE
Отладочная камера

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -75,6 +75,72 @@ I={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":73,"key_label":0,"unicode":105,"echo":false,"script":null)
 ]
 }
+F3={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194334,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+1={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":49,"key_label":0,"unicode":49,"echo":false,"script":null)
+]
+}
+2={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":50,"key_label":0,"unicode":50,"echo":false,"script":null)
+]
+}
+3={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":51,"key_label":0,"unicode":51,"echo":false,"script":null)
+]
+}
+4={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":52,"key_label":0,"unicode":52,"echo":false,"script":null)
+]
+}
+5={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":53,"key_label":0,"unicode":53,"echo":false,"script":null)
+]
+}
+6={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":54,"key_label":0,"unicode":54,"echo":false,"script":null)
+]
+}
+7={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":55,"key_label":0,"unicode":55,"echo":false,"script":null)
+]
+}
+8={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":56,"key_label":0,"unicode":56,"echo":false,"script":null)
+]
+}
+9={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":57,"key_label":0,"unicode":57,"echo":false,"script":null)
+]
+}
++={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194437,"key_label":0,"unicode":43,"echo":false,"script":null)
+]
+}
+-={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":45,"key_label":0,"unicode":45,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194435,"key_label":0,"unicode":45,"echo":false,"script":null)
+]
+}
+"Block F3 cam"={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":66,"key_label":0,"unicode":98,"echo":false,"script":null)
+]
+}
 
 [input_devices]
 

--- a/scenes/Entities/Res/res.gd
+++ b/scenes/Entities/Res/res.gd
@@ -1,1 +1,3 @@
 extends Body
+
+#wefffvwhj

--- a/scenes/Entities/Res/res.gd
+++ b/scenes/Entities/Res/res.gd
@@ -1,3 +1,2 @@
 extends Body
 
-#wefffvwhj

--- a/scenes/Entities/Skills/Move.gd
+++ b/scenes/Entities/Skills/Move.gd
@@ -5,10 +5,7 @@ extends Node2D
 @onready var SkinPlayer = $"../../Skin"
 
 func _process(delta):
-	if Global.playercam_eneble:
-		$"../../Camera2D".enabled = true
-	else:
-		$"../../Camera2D".enabled = false
+	$"../../Camera2D".enabled = Global.player_camera_enable
 	if ["W", "A", "S", "D"].any(Input.is_action_pressed) and (body.current_state == body.States.IDLE or body.current_state == body.States.MOVE) and Global.player_canmove:
 		body.current_state = body.States.MOVE
 		body.current_state = body.States.MOVE

--- a/scenes/Entities/Skills/Move.gd
+++ b/scenes/Entities/Skills/Move.gd
@@ -5,7 +5,12 @@ extends Node2D
 @onready var SkinPlayer = $"../../Skin"
 
 func _process(delta):
-	if ["W", "A", "S", "D"].any(Input.is_action_pressed) and (body.current_state == body.States.IDLE or body.current_state == body.States.MOVE):
+	if Global.playercam_eneble:
+		$"../../Camera2D".enabled = true
+	else:
+		$"../../Camera2D".enabled = false
+	if ["W", "A", "S", "D"].any(Input.is_action_pressed) and (body.current_state == body.States.IDLE or body.current_state == body.States.MOVE) and Global.player_canmove:
+		body.current_state = body.States.MOVE
 		body.current_state = body.States.MOVE
 		move()
 	elif body.current_state == body.States.MOVE:

--- a/scenes/Game/Camera.gd
+++ b/scenes/Game/Camera.gd
@@ -1,0 +1,85 @@
+extends Node2D
+
+@onready var cam = $Camera2D
+@onready var label = $"../CanvasLayer/Label"
+
+
+var speed = 10
+var cam_move = true
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	cam.enabled = false
+	$"../CanvasLayer/Camspeed".visible = false
+	update_text()
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(_delta):
+	if Input.is_action_just_pressed("F3") and cam.enabled == false:
+		if cam_move == false:
+			cam_move = true
+		label.visible = false
+		$"../CanvasLayer/Camspeed".visible = true
+		Global.player_canmove = false
+		Global.playercam_eneble = false
+		cam.enabled = true
+	elif Input.is_action_just_pressed("F3") and cam.enabled == true:
+		$"../CanvasLayer/Camspeed".visible = false
+		label.visible = true
+		Global.player_canmove = true
+		Global.playercam_eneble = true
+		cam.enabled = false
+	if cam.enabled == true and Input.is_action_just_pressed("Block F3 cam") and cam_move == true:
+		cam_move = false
+		Global.player_canmove = true
+	elif cam.enabled == true and Input.is_action_just_pressed("Block F3 cam") and cam_move == false:
+		cam_move = true
+		Global.player_canmove = false
+	if ["W", "A", "S", "D"].any(Input.is_action_pressed) and cam.enabled == true and cam_move:
+		cam.position += Vector2(Input.get_axis("A", "D"), Input.get_axis("W", "S")).normalized() * speed
+	
+	if Input.is_action_just_pressed("+") and !cam.enabled == false :
+		speed += 10
+		update_text()
+	elif Input.is_action_just_pressed("-") and !cam.enabled == false and speed > 10:
+		speed -= 10
+		update_text()
+	if cam.enabled == true:
+		if Input.is_action_just_pressed("1"):
+			change_pos(Vector2(0, 440))
+		elif Input.is_action_just_pressed("2"):
+			change_pos(Vector2(-20000, 440))
+		elif Input.is_action_just_pressed("3"):
+			change_pos(Vector2(-20000, -17300))
+		elif Input.is_action_just_pressed("4"):
+			change_pos(Vector2(0, -17300))
+		elif Input.is_action_just_pressed("5"):
+			change_pos(Vector2(20000, -17300))
+		elif Input.is_action_just_pressed("6"):
+			change_pos(Vector2(20000, 440))
+		elif Input.is_action_just_pressed("7"):
+			change_pos(Vector2(20000, 17300))
+		elif Input.is_action_just_pressed("8"):
+			change_pos(Vector2(0, 17300))
+		elif Input.is_action_just_pressed("9"):
+			change_pos(Vector2(-20000, 17300))
+	
+
+
+func _input(event):
+	if event is InputEventMouseButton and cam.enabled == true:
+		if event.button_index == MOUSE_BUTTON_WHEEL_UP:
+			cam.zoom += Vector2(0.01, 0.01)
+		elif event.button_index == MOUSE_BUTTON_WHEEL_DOWN and cam.zoom > Vector2(0.01, 0.01):
+			cam.zoom -= Vector2(0.01, 0.01)
+func change_pos (key: Vector2):
+	cam.position = Vector2(key)
+	if key == Vector2(0, 440):
+		$"../Player".position = Vector2(-5067, 775)
+	else:
+		$"../Player".position = cam.position
+		
+	
+	
+func update_text ():
+	$"../CanvasLayer/Camspeed".text = "Camera speed: " + str(speed / 10)

--- a/scenes/Game/Camera.gd
+++ b/scenes/Game/Camera.gd
@@ -2,10 +2,20 @@ extends Node2D
 
 @onready var cam = $Camera2D
 @onready var label = $"../CanvasLayer/Label"
+@onready var island1 = $"../islnd/Islands".position
+@onready var islands_2 = $"../islnd/Islands2".position
+@onready var islands_3 = $"../islnd/Islands3".position
+@onready var islands_4 = $"../islnd/Islands4".position
+@onready var islands_5 = $"../islnd/Islands5".position
+@onready var islands_6 = $"../islnd/Islands6".position
+@onready var islands_7 = $"../islnd/Islands7".position
+@onready var islands_8 = $"../islnd/Islands8".position
+@onready var islands_9 = $"../islnd/Islands9".position
 
 
 var speed = 10
 var cam_move = true
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	cam.enabled = false
@@ -38,36 +48,36 @@ func _process(_delta):
 	if ["W", "A", "S", "D"].any(Input.is_action_pressed) and cam.enabled == true and cam_move:
 		cam.position += Vector2(Input.get_axis("A", "D"), Input.get_axis("W", "S")).normalized() * speed
 	
-	if Input.is_action_just_pressed("+") and !cam.enabled == false :
+	if Input.is_action_just_pressed("+") and cam.enabled:
 		speed += 10
 		update_text()
-	elif Input.is_action_just_pressed("-") and !cam.enabled == false and speed > 10:
+	elif Input.is_action_just_pressed("-") and cam.enabled == false and speed > 10:
 		speed -= 10
 		update_text()
 	if cam.enabled == true:
 		if Input.is_action_just_pressed("1"):
-			change_pos(Vector2(0, 440))
+			change_pos(island1)
 		elif Input.is_action_just_pressed("2"):
-			change_pos(Vector2(-20000, 440))
+			change_pos(islands_2)
 		elif Input.is_action_just_pressed("3"):
-			change_pos(Vector2(-20000, -17300))
+			change_pos(islands_3)
 		elif Input.is_action_just_pressed("4"):
-			change_pos(Vector2(0, -17300))
+			change_pos(islands_4)
 		elif Input.is_action_just_pressed("5"):
-			change_pos(Vector2(20000, -17300))
+			change_pos(islands_5)
 		elif Input.is_action_just_pressed("6"):
-			change_pos(Vector2(20000, 440))
+			change_pos(islands_6)
 		elif Input.is_action_just_pressed("7"):
-			change_pos(Vector2(20000, 17300))
+			change_pos(islands_7)
 		elif Input.is_action_just_pressed("8"):
-			change_pos(Vector2(0, 17300))
+			change_pos(islands_8)
 		elif Input.is_action_just_pressed("9"):
-			change_pos(Vector2(-20000, 17300))
+			change_pos(islands_9)
 	
 
 
 func _input(event):
-	if event is InputEventMouseButton and cam.enabled == true:
+	if event is InputEventMouseButton and cam.enabled:
 		if event.button_index == MOUSE_BUTTON_WHEEL_UP:
 			cam.zoom += Vector2(0.01, 0.01)
 		elif event.button_index == MOUSE_BUTTON_WHEEL_DOWN and cam.zoom > Vector2(0.01, 0.01):

--- a/scenes/Game/Camera.gd
+++ b/scenes/Game/Camera.gd
@@ -21,13 +21,13 @@ func _process(_delta):
 		label.visible = false
 		$"../CanvasLayer/Camspeed".visible = true
 		Global.player_canmove = false
-		Global.playercam_eneble = false
+		Global.player_camera_enable = false
 		cam.enabled = true
 	elif Input.is_action_just_pressed("F3") and cam.enabled == true:
 		$"../CanvasLayer/Camspeed".visible = false
 		label.visible = true
 		Global.player_canmove = true
-		Global.playercam_eneble = true
+		Global.player_camera_enable = true
 		cam.enabled = false
 	if cam.enabled == true and Input.is_action_just_pressed("Block F3 cam") and cam_move == true:
 		cam_move = false

--- a/scenes/Game/game.tscn
+++ b/scenes/Game/game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://ck1jdw71slkbf"]
+[gd_scene load_steps=14 format=3 uid="uid://ck1jdw71slkbf"]
 
 [ext_resource type="PackedScene" uid="uid://bqhegexofc3wb" path="res://scenes/Islands/islands.tscn" id="1_mhpm1"]
 [ext_resource type="PackedScene" uid="uid://wcix67e82g86" path="res://scenes/Entities/Player/player.tscn" id="2_kc6yd"]
@@ -10,6 +10,7 @@
 [ext_resource type="PackedScene" uid="uid://oudduvyysxcl" path="res://scenes/Entities/Enemy/zombi.tscn" id="9_6cljr"]
 [ext_resource type="PackedScene" uid="uid://bo6sbhfc6e5y6" path="res://scenes/items/sword.tscn" id="10_60dle"]
 [ext_resource type="PackedScene" uid="uid://d17g01y2hx4tt" path="res://gold.tscn" id="10_ctimv"]
+[ext_resource type="Script" path="res://scenes/Game/Camera.gd" id="11_cp2go"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_qcmir"]
 radius = 40.0
@@ -94,6 +95,10 @@ theme_override_font_sizes/font_size = 60
 text = "MONEY:"
 script = SubResource("GDScript_ptu1r")
 
+[node name="Camspeed" type="Label" parent="CanvasLayer"]
+offset_right = 40.0
+offset_bottom = 23.0
+
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("7_i1pqy")
 volume_db = -10.38
@@ -121,5 +126,12 @@ position = Vector2(-4634, 519)
 
 [node name="Sword3" parent="." instance=ExtResource("10_60dle")]
 position = Vector2(-5895, 587)
+
+[node name="Node2D" type="Node2D" parent="."]
+script = ExtResource("11_cp2go")
+
+[node name="Camera2D" type="Camera2D" parent="Node2D"]
+position = Vector2(0, 440)
+zoom = Vector2(0.08, 0.08)
 
 [connection signal="body_entered" from="Weapon/shape" to="Weapon" method="_on_shape_body_entered"]

--- a/scripts/global.gd
+++ b/scripts/global.gd
@@ -3,4 +3,6 @@ extends Node
 
 var player_pos = Vector2.ZERO
 var gold : int
+var playercam_eneble = true
+var player_canmove = true
 

--- a/scripts/global.gd
+++ b/scripts/global.gd
@@ -3,6 +3,6 @@ extends Node
 
 var player_pos = Vector2.ZERO
 var gold : int
-var playercam_eneble = true
+var player_camera_enable = true
 var player_canmove = true
 


### PR DESCRIPTION
*Отладочная камера* 
управление: WASD-передвижение, F3-вкл отклад. камеру, 1,2,3,4,5,6,7,8,9-передвижение по островам(их текстурку удалили, включите видимость колизии если хотите) , - и + это увеличение и уменьшение скорости камеры, колесиком мыши приближение и отдаление, если в режиме отлад.камеры нажать B-камера заблокируеться в этом положении и можно будет вместо камеры управлять игроком,
выйти из отклад. камеры - второй раз нажать F3